### PR TITLE
Enhance safe redirect

### DIFF
--- a/src/utils/get-safe-redirect.js
+++ b/src/utils/get-safe-redirect.js
@@ -1,5 +1,5 @@
 function getSafeRedirect (redirect) {
-  if (!redirect?.startsWith('/')) {
+  if (!redirect?.startsWith('/') || redirect.startsWith('//')) {
     return '/home'
   }
   return redirect

--- a/test/unit/utils/get-safe-redirect.test.js
+++ b/test/unit/utils/get-safe-redirect.test.js
@@ -28,4 +28,14 @@ describe('getSafeRedirect', () => {
     const result = getSafeRedirect(null)
     expect(result).toBe('/home')
   })
+
+  test('should return "/home" if redirect starts with //', () => {
+    const result = getSafeRedirect('//evil.com')
+    expect(result).toBe('/home')
+  })
+
+  test('should return "/home" for backslash at start', () => {
+    const result = getSafeRedirect(String.raw`\admin\payments`)
+    expect(result).toBe('/home')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes an open redirect vulnerability where a `//`-prefixed URL (protocol-relative redirect) could be used to redirect users to an external domain.

### Changes

- **`src/utils/get-safe-redirect.js`**: Added `|| redirect.startsWith('//')` to the guard condition so protocol-relative URLs such as `//evil.com` are rejected and fall back to `/home`.
- **`test/unit/utils/get-safe-redirect.test.js`**: Added two new tests covering the `//` protocol-relative case and a backslash-prefixed path.

### Security fix

Before this change, `getSafeRedirect('//evil.com')` returned `//evil.com`, which browsers interpret as a protocol-relative URL — allowing an attacker to redirect users to an external site.